### PR TITLE
fix: node-next and the weird case of importing ts code from js files

### DIFF
--- a/src/MetricsProvider.ts
+++ b/src/MetricsProvider.ts
@@ -1,4 +1,4 @@
-import { COUNTLY_API_URL } from './config.js'
+import { COUNTLY_API_URL } from './config'
 import type { consentTypes, consentTypesExceptAll, metricFeatures } from 'countly-sdk-web'
 import Countly from 'countly-sdk-web'
 

--- a/src/components/ConsentBanner/index.ts
+++ b/src/components/ConsentBanner/index.ts
@@ -1,1 +1,1 @@
-export { default } from './ConsentBanner.js'
+export { default } from './ConsentBanner'

--- a/src/components/ConsentToggle/ConsentToggle.stories.tsx
+++ b/src/components/ConsentToggle/ConsentToggle.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import ConsentToggle from "./ConsentToggle.js";
-import type { ConsentToggleProps } from './ConsentToggle.js';
+import ConsentToggle from "./ConsentToggle";
+import type { ConsentToggleProps } from './ConsentToggle';
 
 export default {
     title: "Metrics Consent Toggle",

--- a/src/components/ConsentToggle/index.ts
+++ b/src/components/ConsentToggle/index.ts
@@ -1,1 +1,1 @@
-export { default } from './ConsentToggle.js'
+export { default } from './ConsentToggle'

--- a/src/components/Warning/index.ts
+++ b/src/components/Warning/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Warning.js'
+export { default } from './Warning'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,3 @@
-export { default as ConsentBanner } from './ConsentBanner/index.js'
-export { default as ConsentToggle } from './ConsentToggle/index.js'
-export { default as Warning } from './Warning/index.js'
+export { default as ConsentBanner } from './ConsentBanner'
+export { default as ConsentToggle } from './ConsentToggle'
+export { default as Warning } from './Warning'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from './components/index.js'
-export * from './MetricsProvider.js'
+export * from './components'
+export * from './MetricsProvider'

--- a/stories/Example/Example.stories.tsx
+++ b/stories/Example/Example.stories.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import ConsentBanner from '../../src/components/ConsentBanner/index.js';
-import ConsentToggle from '../../src/components/ConsentToggle/index.js';
-import Warning from '../../src/components/Warning/index.js';
-import { COUNTLY_API_URL } from '../../src/config.js';
+import ConsentBanner from '../../src/components/ConsentBanner';
+import ConsentToggle from '../../src/components/ConsentToggle';
+import Warning from '../../src/components/Warning';
+import { COUNTLY_API_URL } from '../../src/config';
 import MetricsProvider from '../../src/MetricsProvider';
 import './Example.css';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,11 @@
     "jsx": "react",
     "types": ["node"],
     "outDir": "dist",
-    "target": "ES6",
+    "target": "ESNext",
     "allowSyntheticDefaultImports": true,
-    "moduleResolution": "NodeNext"
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Node"
   },
   "include": [
     "src",


### PR DESCRIPTION
In this PR:

- I don't think `nodenext` is ready for primetime, it results in cognitive dissonance and poor DX.
- There is an entire thread: https://github.com/microsoft/TypeScript/issues/49083 where devs just vetoed based on philosophy rather than what's ergonomic.
- It just feels weird import TS code from JS files and believe it's true.
- Also, `index` files should be resolved automatically so fixed that too.