### PR TITLE
fix: expose more tracking methods

### DIFF
--- a/src/MetricsProvider.ts
+++ b/src/MetricsProvider.ts
@@ -1,6 +1,6 @@
 import { COUNTLY_SETUP_DEFAULTS } from './config.js'
 
-import type { metricFeatures, CountlyWebSdk } from 'countly-sdk-web'
+import type { metricFeatures, CountlyWebSdk, IgnoreList, Segments, CountlyEvent } from 'countly-sdk-web'
 import type { CountlyNodeSdk } from 'countly-sdk-nodejs'
 import type { consentTypes, consentTypesExceptAll } from './types/index.js'
 import type { StorageProvider } from './StorageProvider.js'
@@ -134,6 +134,39 @@ export default class MetricsProvider<T extends CountlyWebSdk | CountlyNodeSdk> {
         this.removeConsent(groupName as consentTypes)
       }
     })
+  }
+
+  /**
+   * Track a page view
+   *
+   * Leave arguments empty to have countly automatically track the events for you.
+   *
+   * @param page - The page name to track
+   * @param ignoreList - A list of urls to ignore
+   * @param viewSegments - A list of segments to add to the view event
+   */
+  trackView (page?: string, ignoreList?: IgnoreList, viewSegments?: Segments): void {
+    this.metricsService.track_view(page, ignoreList, viewSegments)
+  }
+
+  /**
+   * Track a custom event
+   *
+   * @param event - The event to add to the queue
+   */
+  trackEvent (event: CountlyEvent): void {
+    this.metricsService.add_event(event)
+  }
+
+  /**
+   * Track an Error
+   *
+   * @param error - The Error instance
+   * @param nonFatal - Whether the error is fatal or not
+   * @param segments - A list of segments to add to the error event
+   */
+  trackError (error: Error, nonFatal = true, segments: Segments = {}): void {
+    this.metricsService.recordError(error, nonFatal, segments)
   }
 
   /**

--- a/src/types/countly.d.ts
+++ b/src/types/countly.d.ts
@@ -126,11 +126,11 @@ declare module 'countly-sdk-web' {
     log_error: (err, segments) => void
 
     /**
-     *  Record and report error, this is where tracked errors are modified and sent to the request queue
+     * Record and report error, this is where tracked errors are modified and sent to the request queue
      *
-     *  @param {Error} err - Error object
-     *  @param {boolean} nonfatal - nonfatal if true and false if fatal
-     *  @param {Segments} segments - custom crash segments
+     * @param {Error} err - Error object
+     * @param {boolean} nonfatal - nonfatal if true and false if fatal
+     * @param {Segments} segments - custom crash segments
      */
     recordError: (err, nonfatal, segments) => void
   }

--- a/src/types/countly.d.ts
+++ b/src/types/countly.d.ts
@@ -5,7 +5,7 @@ declare module 'countly-sdk-web' {
     sum: number
     segmentation: Record<string, string | number>
   }
-  interface CountlyEvent {
+  export interface CountlyEvent {
     // name or id of the event
     key: string
     // how many times did event occur
@@ -20,8 +20,8 @@ declare module 'countly-sdk-web' {
 
   export type metricFeatures = 'apm' | 'attribution' | 'clicks' | 'crashes' | 'events' | 'feedback' | 'forms' |
   'location' | 'scrolls' | 'sessions' | 'star-rating' | 'users' | 'views'
-  type Segments = Record<string, string>
-  type IgnoreList = Array<string | RegExp>
+  export type Segments = Record<string, string>
+  export type IgnoreList = Array<string | RegExp>
   type CountlyEventQueueItem = [string, CountlyEventData] | [eventName: string, key: string] | [eventName: string]
   export interface CountlyWebSdk {
     group_features: (arg0: Record<import('./index.js').consentTypes, metricFeatures[]>) => unknown
@@ -115,6 +115,24 @@ declare module 'countly-sdk-web' {
      * @returns {void}
      */
     end_session: (sec, force) => void
+
+    /**
+     * Log an exception that you caught through try and catch block and handled yourself and just want to report it to server
+     * Note: calls recordError internally
+     *
+     * @param {Error} err - error exception object provided in catch block
+     * @param {Segments} segments - additional key value pairs you want to provide with error report, like versions of libraries used, etc.
+     */
+    log_error: (err, segments) => void
+
+    /**
+     *  Record and report error, this is where tracked errors are modified and sent to the request queue
+     *
+     *  @param {Error} err - Error object
+     *  @param {boolean} nonfatal - nonfatal if true and false if fatal
+     *  @param {Segments} segments - custom crash segments
+     */
+    recordError: (err, nonfatal, segments) => void
   }
   const Countly: CountlyWebSdk
   export default Countly


### PR DESCRIPTION
This PR simply exposes more method wrappers so we don't need to do things like this: https://github.com/ipfs/ipfs-companion/blob/d334ec0ae24f93fb5174d497e04b6ad257d7a330/add-on/src/lib/telemetry.js#L62

We want to be the abstraction layer for our metricsProvider, so that we can switch from countly, or others, easily.